### PR TITLE
style: 💄 Remove some absolute size definitions

### DIFF
--- a/Marsher/MainWindow.xaml
+++ b/Marsher/MainWindow.xaml
@@ -78,7 +78,7 @@
         <Grid DockPanel.Dock="Top">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="280" />
-                <ColumnDefinition Width="2" />
+                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
@@ -125,7 +125,7 @@
             <Grid Grid.Column="2">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="220" />
-                    <RowDefinition Height="5" />
+                    <RowDefinition Height="Auto" />
                     <RowDefinition />
                     <RowDefinition Height="50"/>
                 </Grid.RowDefinitions>


### PR DESCRIPTION
Do not add too many absolute size definitions in the app. Although you know that the size of the element "GridSplitter" won't be changed in the runtim
e, you should still use 'Width="Auto"' in the "RowDefinition". The absolute size should always get from the size of the child element by the
app in the runtime because we don't want some changes that causing some problems in the size of the elements in the future. 